### PR TITLE
dev-env: separate backend and auth for user-auth

### DIFF
--- a/templates/src/api/kratos.js
+++ b/templates/src/api/kratos.js
@@ -6,8 +6,8 @@ const capitalize = (str) => `${str[0].toUpperCase()}${str.slice(1)}`
  * Kratos redirects and sets cookie upon client lands on URL and redirects back to
  * frontend with request_id
  *  */
-const authPublicURL = `${config.backendURL}/.ory/kratos/public`;
-const authAdminURL = `${config.backendURL}/.ory/kratos`;
+const authPublicURL = `${config.authBackendURL}/.ory/kratos/public`;
+const authAdminURL = `${config.authBackendURL}/.ory/kratos`;
 
 /**
  * publicApi / adminApi are initialized Kratos SDK client with public / admin endpoints,

--- a/templates/src/config/development.json
+++ b/templates/src/config/development.json
@@ -1,6 +1,10 @@
 {
     "appName": "<% .Name %>",
     "environment": "development",
-    "backendURL": "http://localhost:8080"<%if eq (index .Params `billingEnabled`) "yes" %>,
+    "backendURL": "http://localhost:8080"
+    <%- if eq (index .Params `billingEnabled`) "yes" %>,
+    "authBackendURL": "https://dev.<% index .Params `stagingHostRoot` %>",
+    <% end %>
+    <%- if eq (index .Params `billingEnabled`) "yes" %>,
     "stripePublishableKey": "<% index .Params `stagingStripePublicApiKey` %>"<% end %>
 }

--- a/templates/src/config/production.json
+++ b/templates/src/config/production.json
@@ -1,6 +1,7 @@
 {
     "appName": "<% .Name %>",
     "environment": "production",
-    "backendURL": "https://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>"<%if eq (index .Params `billingEnabled`) "yes" %>,
+    "backendURL": "https://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>",
+    "authBackendURL": "https://<% index .Params `productionBackendSubdomain` %><% index .Params `productionHostRoot` %>"<%if eq (index .Params `billingEnabled`) "yes" %>,
     "stripePublishableKey": "<% index .Params `productionStripePublicApiKey` %>"<% end %>
 }

--- a/templates/src/config/staging.json
+++ b/templates/src/config/staging.json
@@ -1,6 +1,7 @@
 {
     "appName": "<% .Name %>",
     "environment": "staging",
-    "backendURL": "https://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>"<%if eq (index .Params `billingEnabled`) "yes" %>,
+    "backendURL": "https://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>",
+    "authBackendURL": "https://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>"<%if eq (index .Params `billingEnabled`) "yes" %>,
     "stripePublishableKey": "<% index .Params `stagingStripePublicApiKey` %>"<% end %>
 }


### PR DESCRIPTION
this requires a separate shared kratos to be spun up for dev
endpoints will change to the following format:
previously: <developer-namespace>.<domain>
auth endpoints:    dev.<domain>
backend endpoints: <developer-namespace>.dev.<domain>
and cookies for auth would be set on dev.<domain> so can share session